### PR TITLE
Change readme filetype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["Roman Netrogolov <romius2001@gmail.com>",
 	   "Anna Bubnova <banuba313@gmail.com>",
 	   "Yury Kaminsky <jkaminski@niuitmo.ru>"]
 license = "MIT"
-readme = "readme.md"
+readme = "readme.rst"
 repository = "https://github.com/ITMO-NSS-team/BAMT"
 
 classifiers = ["Programming Language :: Python :: 3",


### PR DESCRIPTION
Fix for error during preparing metadata.
The problem occurs whet user executes `pip install git+url` due to uncorrect filetype for readme